### PR TITLE
Support Google Chrome Canary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "testcafe-test-runner",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -800,8 +800,7 @@
         "graceful-fs": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-            "dev": true
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "graceful-readlink": {
             "version": "1.0.1",
@@ -1497,6 +1496,14 @@
                 "readable-stream": "2.3.3"
             }
         },
+        "linux-platform-info": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/linux-platform-info/-/linux-platform-info-0.0.3.tgz",
+            "integrity": "sha1-La4yQ4Xmbj11W+yD+Gx77qYc64M=",
+            "requires": {
+                "os-family": "1.0.0"
+            }
+        },
         "lodash._baseassign": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
@@ -1736,14 +1743,12 @@
         "minimist": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             }
@@ -2467,12 +2472,15 @@
             }
         },
         "testcafe-browser-tools": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-1.1.7.tgz",
-            "integrity": "sha1-6o31hTJjqPFFNFfBap05jEX6cJc=",
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-1.4.6.tgz",
+            "integrity": "sha512-kBderW2L9u+ecAFp9przMPHLwrMPHfAq4tIHeFqykGHL/8K+ydOXYerfKKNrxiSvmvSHs+aWLlr/+/4q+TE+kg==",
             "requires": {
                 "array-find": "1.0.0",
                 "babel-runtime": "5.8.38",
+                "graceful-fs": "4.1.11",
+                "linux-platform-info": "0.0.3",
+                "mkdirp": "0.5.1",
                 "mustache": "2.3.0",
                 "os-family": "1.0.0",
                 "pify": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,358 +1,396 @@
 {
-    "name": "testcafe-test-runner",
-    "displayName": "TestCafe Test Runner",
-    "description": "Allows to run TestCafe tests directly from VS Code via context menu or built-in commands",
-    "version": "1.4.1",
-    "publisher": "romanresh",
-    "icon": "images/icon.png",
-    "engines": {
-        "vscode": "^1.15.0"
-    },
-    "categories": [
-        "Other",
-        "Debuggers"
-    ],
-    "keywords": [
-        "TestCafe",
-        "Test",
-        "Runner"
-    ],
-    "activationEvents": [
-        "onLanguage:javascript",
-        "onLanguage:typescript"
-    ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "configuration": {
-            "title": "TestCafe Test Runner configuration",
-            "type": "object",
-            "properties": {
-                "testcafeTestRunner.customArguments": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "Specifies custom arguments of the TestCafe Command Line Interface"
-                },
-                "testcafeTestRunner.workspaceRoot": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": "./",
-                    "description": "Specifies a relative path to a folder with node_modules which contains the TestCafe package"
-                }
-            }
-        },
-        "commands": [
-            {
-                "command": "testcaferunner.runTestsInIE",
-                "title": "TestCafe: Run Test(s) in IE"
-            },
-            {
-                "command": "testcaferunner.runTestsInFirefox",
-                "title": "TestCafe: Run Test(s) in Firefox"
-            },
-            {
-                "command": "testcaferunner.runTestsInChrome",
-                "title": "TestCafe: Run Test(s) in Chrome"
-            },
-            {
-                "command": "testcaferunner.runTestsInChromium",
-                "title": "TestCafe: Run Test(s) in Chromium"
-            },
-            {
-                "command": "testcaferunner.runTestsInOpera",
-                "title": "TestCafe: Run Test(s) in Opera"
-            },
-            {
-                "command": "testcaferunner.runTestsInSafari",
-                "title": "TestCafe: Run Test(s) in Safari"
-            },
-            {
-                "command": "testcaferunner.runTestsInEdge",
-                "title": "TestCafe: Run Test(s) in Edge"
-            },
-            {
-                "command": "testcaferunner.runTestFileInIE",
-                "title": "TestCafe: Run Test(s) in IE"
-            },
-            {
-                "command": "testcaferunner.runTestFileInFirefox",
-                "title": "TestCafe: Run Test(s) in Firefox"
-            },
-            {
-                "command": "testcaferunner.runTestFileInChrome",
-                "title": "TestCafe: Run Test(s) in Chrome"
-            },
-            {
-                "command": "testcaferunner.runTestFileInChromium",
-                "title": "TestCafe: Run Test(s) in Chromium"
-            },
-            {
-                "command": "testcaferunner.runTestFileInOpera",
-                "title": "TestCafe: Run Test(s) in Opera"
-            },
-            {
-                "command": "testcaferunner.runTestFileInSafari",
-                "title": "TestCafe: Run Test(s) in Safari"
-            },
-            {
-                "command": "testcaferunner.runTestFileInEdge",
-                "title": "TestCafe: Run Test(s) in Edge"
-            },
-            {
-                "command": "testcaferunner.repeatRun",
-                "title": "TestCafe: Repeat Previous Test Run"
-            },
-            {
-                "command": "testcaferunner.updateBrowserList",
-                "title": "TestCafe: Refresh Browser List"
-            }
-        ],
-        "keybindings": [
-            {
-                "command": "testcaferunner.repeatRun",
-                "key": "CTRL+Alt+P",
-                "mac": "CMD+Alt+P",
-                "when": "testcaferunner.readyForUX && testcaferunner.canRerun"
-            },
-            {
-                "command": "testcaferunner.updateBrowserList",
-                "key": "CTRL+Alt+U",
-                "mac": "CMD+Alt+U",
-                "when": "testcaferunner.readyForUX"
-            }
-        ],
-        "menus": {
-            "editor/context": [
-                {
-                    "when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.ieInstalled",
-                    "command": "testcaferunner.runTestsInIE",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
-                    "command": "testcaferunner.runTestsInFirefox",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
-                    "command": "testcaferunner.runTestsInChrome",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
-                    "command": "testcaferunner.runTestsInChromium",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.operaInstalled",
-                    "command": "testcaferunner.runTestsInOpera",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.safariInstalled",
-                    "command": "testcaferunner.runTestsInSafari",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
-                    "command": "testcaferunner.runTestsInEdge",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.canRerun",
-                    "command": "testcaferunner.repeatRun",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.ieInstalled",
-                    "command": "testcaferunner.runTestsInIE",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
-                    "command": "testcaferunner.runTestsInFirefox",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
-                    "command": "testcaferunner.runTestsInChrome",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
-                    "command": "testcaferunner.runTestsInChromium",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.operaInstalled",
-                    "command": "testcaferunner.runTestsInOpera",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.safariInstalled",
-                    "command": "testcaferunner.runTestsInSafari",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
-                    "command": "testcaferunner.runTestsInEdge",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.canRerun",
-                    "command": "testcaferunner.repeatRun",
-                    "group": "testcaferunner"
-                }
-            ],
-            "explorer/context": [
-                {
-                    "when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.ieInstalled",
-                    "command": "testcaferunner.runTestFileInIE",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
-                    "command": "testcaferunner.runTestFileInFirefox",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
-                    "command": "testcaferunner.runTestFileInChrome",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
-                    "command": "testcaferunner.runTestFileInChromium",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.operaInstalled",
-                    "command": "testcaferunner.runTestFileInOpera",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.safariInstalled",
-                    "command": "testcaferunner.runTestFileInSafari",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
-                    "command": "testcaferunner.runTestFileInEdge",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.ieInstalled",
-                    "command": "testcaferunner.runTestFileInIE",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
-                    "command": "testcaferunner.runTestFileInFirefox",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
-                    "command": "testcaferunner.runTestFileInChrome",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
-                    "command": "testcaferunner.runTestFileInChromium",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.operaInstalled",
-                    "command": "testcaferunner.runTestFileInOpera",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.safariInstalled",
-                    "command": "testcaferunner.runTestFileInSafari",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
-                    "command": "testcaferunner.runTestFileInEdge",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.ieInstalled",
-                    "command": "testcaferunner.runTestFileInIE",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
-                    "command": "testcaferunner.runTestFileInFirefox",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
-                    "command": "testcaferunner.runTestFileInChrome",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
-                    "command": "testcaferunner.runTestFileInChromium",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.operaInstalled",
-                    "command": "testcaferunner.runTestFileInOpera",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.safariInstalled",
-                    "command": "testcaferunner.runTestFileInSafari",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
-                    "command": "testcaferunner.runTestFileInEdge",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.canRerun",
-                    "command": "testcaferunner.repeatRun",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.canRerun",
-                    "command": "testcaferunner.repeatRun",
-                    "group": "testcaferunner"
-                },
-                {
-                    "when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.canRerun",
-                    "command": "testcaferunner.repeatRun",
-                    "group": "testcaferunner"
-                }
-            ]
-        }
-    },
-    "scripts": {
-        "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test"
-    },
-    "dependencies": {
-        "testcafe-browser-tools": "1.4.6"
-    },
-    "devDependencies": {
-        "@types/mocha": "^2.2.32",
-        "@types/node": "^6.0.40",
-        "mocha": "^2.3.3",
-        "typescript": "^2.0.3",
-        "vscode": "^1.1.5"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/romanresh/vscode-testcafe"
-    },
-    "bugs": {
-        "url": "https://github.com/romanresh/vscode-testcafe/issues"
-    }
+	"name": "testcafe-test-runner",
+	"displayName": "TestCafe Test Runner",
+	"description": "Allows to run TestCafe tests directly from VS Code via context menu or built-in commands",
+	"version": "1.4.1",
+	"publisher": "romanresh",
+	"icon": "images/icon.png",
+	"engines": {
+		"vscode": "^1.15.0"
+	},
+	"categories": [
+		"Other",
+		"Debuggers"
+	],
+	"keywords": [
+		"TestCafe",
+		"Test",
+		"Runner"
+	],
+	"activationEvents": [
+		"onLanguage:javascript",
+		"onLanguage:typescript"
+	],
+	"main": "./out/src/extension",
+	"contributes": {
+		"configuration": {
+			"title": "TestCafe Test Runner configuration",
+			"type": "object",
+			"properties": {
+				"testcafeTestRunner.customArguments": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "Specifies custom arguments of the TestCafe Command Line Interface"
+				},
+				"testcafeTestRunner.workspaceRoot": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": "./",
+					"description": "Specifies a relative path to a folder with node_modules which contains the TestCafe package"
+				}
+			}
+		},
+		"commands": [
+			{
+				"command": "testcaferunner.runTestsInIE",
+				"title": "TestCafe: Run Test(s) in IE"
+			},
+			{
+				"command": "testcaferunner.runTestsInFirefox",
+				"title": "TestCafe: Run Test(s) in Firefox"
+			},
+			{
+				"command": "testcaferunner.runTestsInChrome",
+				"title": "TestCafe: Run Test(s) in Chrome"
+			},
+			{
+				"command": "testcaferunner.runTestsInChromeCanary",
+				"title": "TestCafe: Run Test(s) in Chrome Canary"
+			},
+			{
+				"command": "testcaferunner.runTestsInChromium",
+				"title": "TestCafe: Run Test(s) in Chromium"
+			},
+			{
+				"command": "testcaferunner.runTestsInOpera",
+				"title": "TestCafe: Run Test(s) in Opera"
+			},
+			{
+				"command": "testcaferunner.runTestsInSafari",
+				"title": "TestCafe: Run Test(s) in Safari"
+			},
+			{
+				"command": "testcaferunner.runTestsInEdge",
+				"title": "TestCafe: Run Test(s) in Edge"
+			},
+			{
+				"command": "testcaferunner.runTestFileInIE",
+				"title": "TestCafe: Run Test(s) in IE"
+			},
+			{
+				"command": "testcaferunner.runTestFileInFirefox",
+				"title": "TestCafe: Run Test(s) in Firefox"
+			},
+			{
+				"command": "testcaferunner.runTestFileInChrome",
+				"title": "TestCafe: Run Test(s) in Chrome"
+			},
+			{
+				"command": "testcaferunner.runTestFileInChromeCanary",
+				"title": "TestCafe: Run Test(s) in Chrome Canary"
+			},
+			{
+				"command": "testcaferunner.runTestFileInChromium",
+				"title": "TestCafe: Run Test(s) in Chromium"
+			},
+			{
+				"command": "testcaferunner.runTestFileInOpera",
+				"title": "TestCafe: Run Test(s) in Opera"
+			},
+			{
+				"command": "testcaferunner.runTestFileInSafari",
+				"title": "TestCafe: Run Test(s) in Safari"
+			},
+			{
+				"command": "testcaferunner.runTestFileInEdge",
+				"title": "TestCafe: Run Test(s) in Edge"
+			},
+			{
+				"command": "testcaferunner.repeatRun",
+				"title": "TestCafe: Repeat Previous Test Run"
+			},
+			{
+				"command": "testcaferunner.updateBrowserList",
+				"title": "TestCafe: Refresh Browser List"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "testcaferunner.repeatRun",
+				"key": "CTRL+Alt+P",
+				"mac": "CMD+Alt+P",
+				"when": "testcaferunner.readyForUX && testcaferunner.canRerun"
+			},
+			{
+				"command": "testcaferunner.updateBrowserList",
+				"key": "CTRL+Alt+U",
+				"mac": "CMD+Alt+U",
+				"when": "testcaferunner.readyForUX"
+			}
+		],
+		"menus": {
+			"editor/context": [
+				{
+					"when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.ieInstalled",
+					"command": "testcaferunner.runTestsInIE",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
+					"command": "testcaferunner.runTestsInFirefox",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
+					"command": "testcaferunner.runTestsInChrome",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.chrome-canaryInstalled",
+					"command": "testcaferunner.runTestsInChromeCanary",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
+					"command": "testcaferunner.runTestsInChromium",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.operaInstalled",
+					"command": "testcaferunner.runTestsInOpera",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.safariInstalled",
+					"command": "testcaferunner.runTestsInSafari",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
+					"command": "testcaferunner.runTestsInEdge",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == javascript && testcaferunner.readyForUX && testcaferunner.canRerun",
+					"command": "testcaferunner.repeatRun",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.ieInstalled",
+					"command": "testcaferunner.runTestsInIE",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
+					"command": "testcaferunner.runTestsInFirefox",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
+					"command": "testcaferunner.runTestsInChrome",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.chrome-canaryInstalled",
+					"command": "testcaferunner.runTestsInChromeCanary",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
+					"command": "testcaferunner.runTestsInChromium",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.operaInstalled",
+					"command": "testcaferunner.runTestsInOpera",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.safariInstalled",
+					"command": "testcaferunner.runTestsInSafari",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
+					"command": "testcaferunner.runTestsInEdge",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "editorLangId == typescript && testcaferunner.readyForUX && testcaferunner.canRerun",
+					"command": "testcaferunner.repeatRun",
+					"group": "testcaferunner"
+				}
+			],
+			"explorer/context": [
+				{
+					"when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.ieInstalled",
+					"command": "testcaferunner.runTestFileInIE",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
+					"command": "testcaferunner.runTestFileInFirefox",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
+					"command": "testcaferunner.runTestFileInChrome",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.chrome-canaryInstalled",
+					"command": "testcaferunner.runTestFileInChromeCanary",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
+					"command": "testcaferunner.runTestFileInChromium",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.operaInstalled",
+					"command": "testcaferunner.runTestFileInOpera",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.safariInstalled",
+					"command": "testcaferunner.runTestFileInSafari",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
+					"command": "testcaferunner.runTestFileInEdge",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.ieInstalled",
+					"command": "testcaferunner.runTestFileInIE",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
+					"command": "testcaferunner.runTestFileInFirefox",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
+					"command": "testcaferunner.runTestFileInChrome",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.chrome-canaryInstalled",
+					"command": "testcaferunner.runTestFileInChromeCanary",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
+					"command": "testcaferunner.runTestFileInChromium",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.operaInstalled",
+					"command": "testcaferunner.runTestFileInOpera",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.safariInstalled",
+					"command": "testcaferunner.runTestFileInSafari",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
+					"command": "testcaferunner.runTestFileInEdge",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.ieInstalled",
+					"command": "testcaferunner.runTestFileInIE",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.firefoxInstalled",
+					"command": "testcaferunner.runTestFileInFirefox",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.chromeInstalled",
+					"command": "testcaferunner.runTestFileInChrome",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.chrome-canaryInstalled",
+					"command": "testcaferunner.runTestFileInChromeCanary",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.chromiumInstalled",
+					"command": "testcaferunner.runTestFileInChromium",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.operaInstalled",
+					"command": "testcaferunner.runTestFileInOpera",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.safariInstalled",
+					"command": "testcaferunner.runTestFileInSafari",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.edgeInstalled",
+					"command": "testcaferunner.runTestFileInEdge",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == javascript && testcaferunner.readyForUX && testcaferunner.canRerun",
+					"command": "testcaferunner.repeatRun",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "resourceLangId == typescript && testcaferunner.readyForUX && testcaferunner.canRerun",
+					"command": "testcaferunner.repeatRun",
+					"group": "testcaferunner"
+				},
+				{
+					"when": "explorerResourceIsFolder && testcaferunner.readyForUX && testcaferunner.canRerun",
+					"command": "testcaferunner.repeatRun",
+					"group": "testcaferunner"
+				}
+			]
+		}
+	},
+	"scripts": {
+		"vscode:prepublish": "tsc -p ./",
+		"compile": "tsc -watch -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install",
+		"test": "node ./node_modules/vscode/bin/test"
+	},
+	"dependencies": {
+		"testcafe-browser-tools": "1.4.6"
+	},
+	"devDependencies": {
+		"@types/mocha": "^2.2.32",
+		"@types/node": "^6.0.40",
+		"mocha": "^2.3.3",
+		"typescript": "^2.0.3",
+		"vscode": "^1.1.5"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/romanresh/vscode-testcafe"
+	},
+	"bugs": {
+		"url": "https://github.com/romanresh/vscode-testcafe/issues"
+	},
+	"__metadata": {
+		"id": "72f84f96-6dde-41a3-9fec-3ea137cde9d1",
+		"publisherDisplayName": "Roman Resh",
+		"publisherId": "69e83783-010b-45e6-b222-ef4ce6662aaa"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -339,7 +339,7 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
-        "testcafe-browser-tools": "1.1.7"
+        "testcafe-browser-tools": "1.4.6"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.32",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 
 const TEST_OR_FIXTURE_RE = /(^|;|\s+|\/\/|\/\*)fixture\s*(\(.+?\)|`.+?`)|(^|;|\s+|\/\/|\/\*)test\s*\(\s*(.+?)\s*,/gm;
 const CLEANUP_TEST_OR_FIXTURE_NAME_RE = /(^\(?\s*(\'|"|`))|((\'|"|`)\s*\)?$)/g;
-const BROWSER_ALIASES = ['ie', 'firefox', 'chrome', 'chromium', 'opera', 'safari', 'edge'];
+const BROWSER_ALIASES = ['ie', 'firefox', 'chrome', 'chrome-canary', 'chromium', 'opera', 'safari', 'edge'];
 const TESTCAFE_PATH = "./node_modules/testcafe/lib/cli/index.js";
 
 var browserTools = require ('testcafe-browser-tools');
@@ -26,6 +26,11 @@ function registerRunTestsCommands (context:vscode.ExtensionContext){
     context.subscriptions.push(
         vscode.commands.registerCommand('testcaferunner.runTestsInChrome', () => {
             controller.runTests("chrome");
+        })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('testcaferunner.runTestsInChromeCanary', () => {
+            controller.runTests("chrome-canary");
         })
     );
     context.subscriptions.push(
@@ -64,6 +69,11 @@ function registerRunTestFileCommands (context:vscode.ExtensionContext){
     context.subscriptions.push(
         vscode.commands.registerCommand('testcaferunner.runTestFileInChrome', args => {
             controller.startTestRun("chrome", args.fsPath, "file");
+        })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('testcaferunner.runTestFileInChromeCanary', args => {
+            controller.startTestRun("chrome-canary", args.fsPath, "file");
         })
     );
     context.subscriptions.push(


### PR DESCRIPTION
### 🐛 Bug
Currently, `vscode-testcafe` does not differentiate between Google Chrome & Google Chrome Canary. When Chrome is not installed and Canary is installed,`vscode-testcafe` displays a (broken) `TestCafe: Run test(s) in Chrome` context menu item.

### ✅ Solution
Support for `chrome-canary` was added to `testcafe-browser-tools` in https://github.com/DevExpress/testcafe-browser-tools/pull/130. This PR fixes this bug by updating the version of `testcafe-browser-utils` used by `vscode-testcafe` to include support for `chrome-canary`.

### ⭐️ New Feature
Additionally, this PR adds new items to the context menu and command palette so tests can be run in Google Chrome Canary.