### PR TITLE
Cleanup: Remove Optional TestCafe Live

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@
 [TestCafe](https://github.com/DevExpress/testcafe) should be installed in your project as a local package. To install it, use the `npm install testcafe` command.
 For Mac OS, add `TestCafe` to dependencies in your `package.json` file. Your project should contain TestCafe modules in `node_modules\testcafe\...`.
 
-### Optional
-This is only required if you would like the option to use the [TestCafe Live](https://github.com/DevExpress/testcafe-live) runner in place of 
-[TestCafe](https://github.com/DevExpress/testcafe). Note that TestCafe Live depends on TestCafe, but they are separate repositories. In other words, you need to install both TestCafe and TestCafe Live if you wish to use the TestCafe Live runner.
-
-Use the `npm install testcafe-live` command.
-
 ## How to install extension
 
 Install the **TestCafe Test Runner** extension from VS Code Marketplace as described in the VS Code [documentation](https://code.visualstudio.com/Docs/editor/extension-gallery).
@@ -88,7 +82,7 @@ To run built-in commands, press `Ctrl+Shift+P` and type the command name:
     * Example:
 ```
 {
-    "testcafeTestRunner.customArguments": "--speed 0.1"
+    "testcafeTestRunner.customArguments": "--speed 0.1 -L"
 }
 ```
 * *testcafeTestRunner.workspaceRoot* - Specifies a relative path to the folder which contains the node_modules folder with the testcafe package. Use this setting if the test files are located in a nested folder with its own node_modules subdirectory. Default value is `./`;
@@ -98,16 +92,8 @@ To run built-in commands, press `Ctrl+Shift+P` and type the command name:
     "testcafeTestRunner.workspaceRoot": "./acceptance"
 }
 ```
-* *testcafeTestRunner.useLiveRunner* - Specifies which testcafe runner to use (TestCafe Live or TestCafe). Default value is `false`;
-    * Example:
-```
-{
-    "testcafeTestRunner.userLiveRunner": true
-}
-```
 
 ## Sources
 
 * [TestCafe Test Runner](https://github.com/romanresh/vscode-testcafe)
 * [TestCafe](https://github.com/DevExpress/testcafe)
-* [TestCafe Live](https://github.com/DevExpress/testcafe-live)

--- a/package.json
+++ b/package.json
@@ -42,14 +42,6 @@
                     ],
                     "default": "./",
                     "description": "Specifies a relative path to a folder with node_modules which contains the TestCafe package"
-                },
-                "testcafeTestRunner.useLiveRunner": {
-                    "type": [
-                        "boolean",
-                        "null"
-                    ],
-                    "default": false,
-                    "description": "Specifies which testcafe runner to use (TestCafe Live or TestCafe)"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,6 @@ const TEST_OR_FIXTURE_RE = /(^|;|\s+|\/\/|\/\*)fixture\s*(\(.+?\)|`.+?`)|(^|;|\s
 const CLEANUP_TEST_OR_FIXTURE_NAME_RE = /(^\(?\s*(\'|"|`))|((\'|"|`)\s*\)?$)/g;
 const BROWSER_ALIASES = ['ie', 'firefox', 'chrome', 'chrome-canary', 'chromium', 'opera', 'safari', 'edge'];
 const TESTCAFE_PATH = "./node_modules/testcafe/lib/cli/index.js";
-const TESTCAFE_LIVE_PATH = "./node_modules/testcafe-live/lib/index.js"
 
 var browserTools = require ('testcafe-browser-tools');
 let controller: TestCafeTestController = null;
@@ -241,13 +240,6 @@ class TestCafeTestController {
         return ''
     }
 
-    private isLiverRunner(): boolean {
-        const useLiveRunner = vscode.workspace.getConfiguration('testcafeTestRunner').get('useLiveRunner')
-        if (typeof(useLiveRunner) === 'boolean' && useLiveRunner){
-            return useLiveRunner;
-        }
-    }
-
     public startTestRun(browser:string, filePath:string, type:string, name:string = "") {
         if (!type) {
             vscode.window.showErrorMessage(`No tests found. Position the cursor inside a test() function or fixture.`);
@@ -272,8 +264,7 @@ class TestCafeTestController {
         }
 
         const workspacePathOverride = this.getOverriddenWorkspacePath()
-        const runnerPath = (this.isLiverRunner()) ? TESTCAFE_LIVE_PATH : TESTCAFE_PATH;
-        var testCafePath = path.resolve(vscode.workspace.rootPath, workspacePathOverride, runnerPath);
+        var testCafePath = path.resolve(vscode.workspace.rootPath, workspacePathOverride, TESTCAFE_PATH);
         if(!fs.existsSync(testCafePath)) {
             vscode.window.showErrorMessage(`TestCafe package is not found at path ${testCafePath}. Install the testcafe package in your working directory or set the "testcafeTestRunner.workspaceRoot" property.`);
             return;


### PR DESCRIPTION
TestCafe Live has been absorbed into TestCafe. Using live mode with TestCafe >= v1.0.0 can be accomplished by simply adding `-L` or `--live` into the customArguments setting.

## Example
```javascript
{
    ...
    "testcafeTestRunner.customArguments": "-L"
    ...
}
```

- Addresses #30 **Improvement: Utilize Live Mode (Now Included In TestCafe)**

