### PR TITLE
Support quoted args in customArguments setting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -312,7 +312,11 @@ class TestCafeTestController {
 
         var customArguments = vscode.workspace.getConfiguration("testcafeTestRunner").get("customArguments");
         if(typeof(customArguments) === "string") {
-            args = args.concat((<string>customArguments).split(" "));
+            const argPattern = /[^\s"]+|"([^"]*)"/g;
+            do {
+                const match = argPattern.exec(<string>customArguments);
+                if (match !== null) { args.push(match[1] ? match[1] : match[0]); }
+            } while (match !== null);
         }
 
         if (type !== "file") {


### PR DESCRIPTION
Fixes an issue where the settings that contain quoted arguments in the customArguments setting would cause the quoted arguments to be parsed incorrectly. Example:

```
{
  "testcafeTestRunner.customArguments": "--ts-config-path ./e2e/specs/tsconfig.json --env=local --selector-timeout 10000 --debug-on-fail --speed 1 --app \"serve ./e2e -l 4789\"",
  "testcafeTestRunner.workspaceRoot": "."
}
```