### PR TITLE
Issue/48 - Enable Custom Browser Flags for TestCafe Test Runner Extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,9 +307,9 @@ class TestCafeTestController {
         }
         if(this.isHeadlessMode())
             browserArg += HEADLESS_MODE_POSTFIX;
-    
+
         var args = [browserArg, filePath];
-    
+
         var customArguments = vscode.workspace.getConfiguration("testcafeTestRunner").get("customArguments");
         if(typeof(customArguments) === "string") {
             const argPattern = /[^\s"]+|"([^"]*)"/g;
@@ -320,15 +320,25 @@ class TestCafeTestController {
                     if (match[0] !== '--ignore-certificate-errors') {
                         args.push(match[1] ? match[1] : match[0]); 
                     }
+                    if (match[0] === '--ignore-certificate-errors') {
+                        browserArg += ' --ignore-certificate-errors';
+                    }
                 }
             } while (match !== null);
         }
     
+        // Enclose browserArg in quotes if it includes flags
+        if (browserArg.includes(' ')) {
+            browserArg = `'${browserArg}'`;
+        }
+    
+        args[0] = browserArg; // Update the browser argument with the potentially modified browserArg
+
         if (type !== "file") {
             args.push("--" + type);
             args.push(name);
         }
-    
+
         const workspacePathOverride = this.getOverriddenWorkspacePath()
         if(this.isLiverRunner())
             args.push("--live");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,9 +307,9 @@ class TestCafeTestController {
         }
         if(this.isHeadlessMode())
             browserArg += HEADLESS_MODE_POSTFIX;
-
+    
         var args = [browserArg, filePath];
-
+    
         var customArguments = vscode.workspace.getConfiguration("testcafeTestRunner").get("customArguments");
         if(typeof(customArguments) === "string") {
             const argPattern = /[^\s"]+|"([^"]*)"/g;
@@ -320,25 +320,15 @@ class TestCafeTestController {
                     if (match[0] !== '--ignore-certificate-errors') {
                         args.push(match[1] ? match[1] : match[0]); 
                     }
-                    if (match[0] === '--ignore-certificate-errors') {
-                        browserArg += ' --ignore-certificate-errors';
-                    }
                 }
             } while (match !== null);
         }
     
-        // Enclose browserArg in quotes if it includes flags
-        if (browserArg.includes(' ')) {
-            browserArg = `'${browserArg}'`;
-        }
-    
-        args[0] = browserArg; // Update the browser argument with the potentially modified browserArg
-
         if (type !== "file") {
             args.push("--" + type);
             args.push(name);
         }
-
+    
         const workspacePathOverride = this.getOverriddenWorkspacePath()
         if(this.isLiverRunner())
             args.push("--live");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -313,8 +313,9 @@ class TestCafeTestController {
         var customArguments = vscode.workspace.getConfiguration("testcafeTestRunner").get("customArguments");
         if(typeof(customArguments) === "string") {
             const argPattern = /[^\s"]+|"([^"]*)"/g;
+            let match;
             do {
-                const match = argPattern.exec(<string>customArguments);
+                match = argPattern.exec(<string>customArguments);
                 if (match !== null) { 
                     args.push(match[1] ? match[1] : match[0]); 
                     if (match[0] === '--ignore-certificate-errors') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -315,9 +315,15 @@ class TestCafeTestController {
             const argPattern = /[^\s"]+|"([^"]*)"/g;
             do {
                 const match = argPattern.exec(<string>customArguments);
-                if (match !== null) { args.push(match[1] ? match[1] : match[0]); }
+                if (match !== null) { 
+                    args.push(match[1] ? match[1] : match[0]); 
+                    if (match[0] === '--ignore-certificate-errors') {
+                        browserArg += ' --ignore-certificate-errors';
+                    }
+                }
             } while (match !== null);
         }
+        args[0] = browserArg; // Update the browser argument with the potentially modified browserArg
 
         if (type !== "file") {
             args.push("--" + type);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -323,6 +323,12 @@ class TestCafeTestController {
                 }
             } while (match !== null);
         }
+    
+        // Enclose browserArg in quotes if it includes flags
+        if (browserArg.includes(' ')) {
+            browserArg = `'${browserArg}'`;
+        }
+    
         args[0] = browserArg; // Update the browser argument with the potentially modified browserArg
 
         if (type !== "file") {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -317,7 +317,9 @@ class TestCafeTestController {
             do {
                 match = argPattern.exec(<string>customArguments);
                 if (match !== null) { 
-                    args.push(match[1] ? match[1] : match[0]); 
+                    if (match[0] !== '--ignore-certificate-errors') {
+                        args.push(match[1] ? match[1] : match[0]); 
+                    }
                     if (match[0] === '--ignore-certificate-errors') {
                         browserArg += ' --ignore-certificate-errors';
                     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -317,11 +317,11 @@ class TestCafeTestController {
             do {
                 match = argPattern.exec(<string>customArguments);
                 if (match !== null) { 
-                    if (match[0] !== '--ignore-certificate-errors') {
+                    if (match[0] !== '--ignore-certificate-errors' && match[0] !== '--start-fullscreen') {
                         args.push(match[1] ? match[1] : match[0]); 
                     }
-                    if (match[0] === '--ignore-certificate-errors') {
-                        browserArg += ' --ignore-certificate-errors';
+                    if (match[0] === '--ignore-certificate-errors' || match[0] === '--start-fullscreen') {
+                        browserArg += ' ' + match[0];
                     }
                 }
             } while (match !== null);


### PR DESCRIPTION
# Pull Request: Enable Custom Browser Flags for TestCafe Test Runner Extension

## Introduction
This pull request aims to add functionality to the TestCafe Test Runner extension allowing users to include browser-specific flags directly from the Visual Studio Code context menu. Specifically, it enables the `--ignore-certificate-errors` flag to be appended to the browser argument when running tests.

## Changes Made
In the `startTestRun` function within `extension.ts`, I've introduced a check within the loop that processes `customArguments` to detect the `--ignore-certificate-errors` flag. If found, it appends this flag to the `browserArg` string. Additionally, to handle cases where `browserArg` contains spaces due to added flags, I've enclosed `browserArg` in quotes.

Here's the critical section of the updated code:

```typescript
// Check for '--ignore-certificate-errors' flag and append to browserArg
if (match !== null) { 
    args.push(match[1] ? match[1] : match[0]); 
    if (match[0] === '--ignore-certificate-errors') {
        browserArg += ' --ignore-certificate-errors';
    }
}

// Enclose browserArg in quotes if it includes flags
if (browserArg.includes(' ')) {
    browserArg = `'${browserArg}'`;
}

args[0] = browserArg; // Update the browser argument with the potentially modified browserArg
```

## Personal Note
As this is only my second time contributing to an open-source project, I'm relatively new to this process. I've done my best to ensure that my changes follow the project's contribution guidelines and provide a meaningful improvement. I hope my contribution is helpful, and I look forward to any feedback that might further refine these changes.

Thank you for considering my pull request.

Best,
Christopher-C-Robinson
